### PR TITLE
[Feat] Job테스트 실행을 위한 Pytest 환경 구축

### DIFF
--- a/IMJob/settings.py
+++ b/IMJob/settings.py
@@ -1,7 +1,6 @@
 import os
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from dotenv import load_dotenv
 
 
 __AUTHOR__ = "IML"
@@ -9,7 +8,6 @@ __VERSION__ = "0.4.2"
 
 APP_NAME = "IMJob"
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
-load_dotenv(BASE_DIR + '/.env')
 
 
 class Settings(BaseSettings):
@@ -20,3 +18,18 @@ class Settings(BaseSettings):
     contact_name: str = __AUTHOR__
     contact_url: str = "https://github.com/iml1111"
     contact_email: str = "shin10256@gmail.com"
+
+    model_config = SettingsConfigDict(
+        env_file=BASE_DIR + '/.env',
+        env_file_encoding='utf-8'
+    )
+
+
+class TestSettings(Settings):
+    """Test Overriding settings"""
+    test_mode: bool = True
+
+    model_config = SettingsConfigDict(
+        env_file=BASE_DIR + '/.test.env',
+        env_file_encoding='utf-8'
+    )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,35 @@
+import logging
+import pytest
+from loguru import logger
+from settings import TestSettings
+
+# external fixtures
+from _pytest.logging import caplog as _caplog
+
+
+@pytest.fixture(scope='session')
+def anyio_backend():
+    return 'asyncio'
+
+
+@pytest.fixture(scope='session')
+def settings() -> TestSettings:
+    settings = TestSettings()
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def caplog(_caplog):
+    """Overriding pytest-capturelog's caplog fixture."""
+    class PropagatingLogger(logging.Handler):
+        def emit(self, record):
+            logging.getLogger(record.name).handle(record)
+
+    handler_id = logger.add(
+        PropagatingLogger(),
+        format="{message} {extra}",
+        level="DEBUG"
+    )
+    yield _caplog
+    # After the test, remove the handler again
+    logger.remove(handler_id)

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1,0 +1,9 @@
+import pytest
+from job.hello import HelloWorld
+from settings import TestSettings
+
+
+@pytest.mark.anyio
+async def test_sample(settings: TestSettings):
+    await HelloWorld(settings).run()
+    assert True


### PR DESCRIPTION
안녕하세요.

현재 저는 `IMJob` 구조를 통해, 특정 프로젝트의 Background Worker로 구현하여 잘 활용하고있습니다.
여러 Job들이 생겨나면서 Test의 필요성이 점점 대두되어 다음과 같은 PyTest 환경이 구축되면 좋을 것 같아 제안드립니다.

감사합니다 :)
